### PR TITLE
Don't crash when there is no `fixtures` directory

### DIFF
--- a/septentrion/files.py
+++ b/septentrion/files.py
@@ -64,7 +64,10 @@ def get_known_schemas():
 
 
 def get_known_fixtures():
-    return os.listdir(os.path.join(settings.MIGRATIONS_ROOT, "fixtures"))
+    try:
+        return os.listdir(os.path.join(settings.MIGRATIONS_ROOT, "fixtures"))
+    except FileNotFoundError:
+        return []
 
 
 def get_migrations_files_mapping(version):

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -63,6 +63,15 @@ def test_get_known_fixtures(mocker):
     assert values == ["fixtures_16.12.sql"]
 
 
+def test_get_known_fixtures_unknown_path(mocker):
+    mocker.patch("os.listdir", side_effect=FileNotFoundError())
+    settings.consolidate(migrations_root="tests/test_data/sql", verbose=0)
+
+    values = files.get_known_fixtures()
+
+    assert values == []
+
+
 def test_get_known_versions(mocker):
     mocker.patch("septentrion.files.list_dirs", return_value=["16.11", "16.12", "16.9"])
     mocker.patch("os.path.islink", return_value=False)


### PR DESCRIPTION
Same behaviour when the `fixtures` directory is empty or missing.